### PR TITLE
Fix race condition

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,11 +81,18 @@ async def pubsub_single(pubsub: redis.client.PubSub, channel: str):
     except redis.PubSubError as e:
         logging.error("Exception in pubsub_single: %s", e)
 
-async def receive_start_game(websocket: WebSocket, game_id: str, game_data: dict):
+async def wait_pubsub_subscribe(channel: str, subs: int):
+    while True:
+        if await redis_client.pubsub_numsub(channel)[0][1] >= subs:
+            return
+        await asyncio.sleep(0.01)
+
+async def receive_start_game(websocket: WebSocket, game_id: str, game_data: dict) -> int:
     """
     Wait for the start game message from `websocket`, then update the status
     in the database.
     Throws an exception if any other message is recevied.
+    Returns the number of non-host players (subscribers to the start channel)
     """
     data = await websocket.receive_json()
     if data.get("type") != "start_game":
@@ -95,9 +102,11 @@ async def receive_start_game(websocket: WebSocket, game_id: str, game_data: dict
         raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION,
                                  reason="Not enough players to start the game")
     logging.debug("Got start game message for %s", game_id)
+    subs = await redis_client.pubsub_numsub(f"game:{game_id}:start")[0][1]
     await redis_client.publish(f"game:{game_id}:start", '{"type": "start"}')
     game_data["status"] = "playing"
     await redis_client.set(f"game:{game_id}", json.dumps(game_data))
+    return subs
 
 async def get_scoreboard(game_id: str) -> list[tuple[str, int]]:
     """Gets the scoreboard of points for each player of the game"""
@@ -203,7 +212,7 @@ async def websocket_endpoint(websocket: WebSocket):
         async with redis_client.pubsub(ignore_subscribe_messages=True) as pubsub:
             # Wait for host to start the game
             if player_data["is_host"]:
-                await receive_start_game(websocket, game_id, game_data)
+                subs = await receive_start_game(websocket, game_id, game_data)
             elif await pubsub_single(pubsub, f"game:{game_id}:start") == "cancel":
                 await websocket.send_text('{"type": "cancel"}')
                 await websocket.close()
@@ -211,6 +220,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
             await pubsub.subscribe(f"game:{game_id}:channel")
             if player_data["is_host"]:
+                await wait_pubsub_subscribe(f"game:{game_id}:channel", subs)
                 await send_next_round(game_id, 0)
             await asyncio.gather(
                 websocket_loop(websocket, game_id, player_id, game_data, player_data),


### PR DESCRIPTION
Bug sometimes happened where the first round message was being sent before other clients had a chance to subscribe to the Redis pubsub channel, so we now wait for all clients to be subscribed before sending that message. 